### PR TITLE
Build warnings

### DIFF
--- a/composition.lisp
+++ b/composition.lisp
@@ -91,15 +91,20 @@
 
 ;; Compose two types if possible and return the composed type. Also return the
 ;; order in which the types were composed.
+(declaim (ftype (function ((or semtype null) (or semtype null) &key (:op-apply-fn function))
+                          (values (or semtype null) simple-string list))
+                compose-types!))
 (defun compose-types! (x y &key (op-apply-fn #'apply-operator!))
   (if (or (not x) (not y))
-    (or x y)
-    (let ((comp (funcall op-apply-fn x y)))
-      (if comp
-        (values comp "right" (list x y))
-        (progn
-          (setf comp (funcall op-apply-fn y x))
-          (when comp (values comp "left" (list y x))))))))
+    (values (or x y) "none" nil)
+    (let (comp)
+      (cond
+        ((setf comp (funcall op-apply-fn x y))
+         (values comp "right" (list x y)))
+        ((setf comp (funcall op-apply-fn y x))
+         (values comp "left" (list y x)))
+        (t
+          (values nil "none" nil))))))
 
 ;; Given two atomic ULFs, return the type formed after composing (if possible)
 (defun compose-atomic-ulfs! (a b)
@@ -154,10 +159,9 @@
   (ulf-type-string? (read-from-string string-ulf)))
 
 
-(defun compose-type-string-builder (compose-fn str2semtype-fn) "Builds a
-  string-based interface to a type composition function with that functions
-  relevant string-to-semtype mapping function.
-  "
+(defun compose-type-string-builder (compose-fn str2semtype-fn)
+  "Builds a string-based interface to a type composition function with that
+  functions relevant string-to-semtype mapping function."
   #'(lambda (type1 type2)
       (when (and type1 type2)
         (multiple-value-bind
@@ -480,21 +484,19 @@
                    :c-tense 't))
     ;; Fall back to extended-apply-operator! when special cases are not
     ;; relevant.
-    (t (extended-apply-operator! op arg :recurse-fn #'left-right-apply-operator!))))
+    (t (extended-apply-operator! op arg :recurse-fn recurse-fn))))
 
 (defun extended-compose-types! (type1 type2)
   "Compose two types if possible and return the composed type. Also return the
   order in which the types were composed. The strict EL type compositions are
-  extended to include ULF macros and structural relaxations.
-  "
+  extended to include ULF macros and structural relaxations."
   (compose-types! type1 type2 :op-apply-fn #'extended-apply-operator!))
 
 
 (defun extended-compose-type-string! (type1 type2)
   "Given two types as strings, compose them if possible and return the
   resulting type as a string. The strict EL type compositions are extended to
-  include ULF macros and structural relaxations.
-  "
+  include ULF macros and structural relaxations."
   (funcall (compose-type-string-builder #'extended-compose-types!
                                         #'extended-str2semtype)
            type1 type2))

--- a/composition.lisp
+++ b/composition.lisp
@@ -146,8 +146,9 @@
 
 ;; Given a ULF, evaluate the type if possible and return a string representation
 ;; of the type.
-(defun ulf-type-string? (ulf)
-  (semtype2str (ulf-type? ulf)))
+(defun ulf-type-string? (inulf)
+  (util:in-intern (inulf ulf :ulf-lib)
+    (semtype2str (ulf-type? ulf))))
 
 (defun str-ulf-type-string? (string-ulf)
   (ulf-type-string? (read-from-string string-ulf)))

--- a/macro.lisp
+++ b/macro.lisp
@@ -26,11 +26,14 @@
 ;;;  insertion-selector-fn: #'second
 ;;;  bad-use-fn: (lambda (x) (not (and (listp x) (eq 'sub (first x)) (equal (length x) 3))))
 ;;; Returns a function that applies all 'sub macros.
+(declaim (ftype (function (symbol symbol function function function)
+                          function)
+                var-insertion-macro))
 (defun var-insertion-macro (macro-name var-sym
                                        context-selector-fn
                                        insertion-selector-fn
                                        bad-use-fn)
-  (declare (ftype (function ((or list atom)) *) bad-use-fn))
+  (declare (type (function ((or list atom)) t) bad-use-fn))
   (labels
     (;; Helper function that does all the heavy lifting.
      (macro-expand-fn (ulf fail-on-bad-use)

--- a/package.lisp
+++ b/package.lisp
@@ -5,7 +5,7 @@
 
 (defpackage :ulf-lib
   (:nicknames :ulf)
-  (:use :cl :cl-user :ttt :cl-strings :cl-util :cl-ppcre :lisp-unit)
+  (:use :cl :cl-user :ttt :cl-strings :cl-util :cl-ppcre)
   (:shadow :split :insert)
   (:export
     ;; suffix.lisp

--- a/preprocess.lisp
+++ b/preprocess.lisp
@@ -59,12 +59,13 @@
     ((helper (str acc lpcount)
        (multiple-value-bind (sexpr endidx)
          (handler-case (read-from-string str)
-           (end-of-file (c) (values str -1))
-           (sb-int:simple-reader-error (c) (values str -2))
+           (end-of-file () (values str -1))
+           (sb-int:simple-reader-error (c) (declare (ignore c)) (values str -2))
            ;; Allegro common lisp gives a speical error when there's an extra right paren.
            ;(excl::extra-right-paren-error (c) (values str -2))
            )
          ;; Body of multiple-value-bind.
+         (declare (ignore sexpr))
          (cond
            ;; If we got an end of file error and it's not empty, add a paren at
            ;; the end of the current string.
@@ -119,7 +120,8 @@
                (setf start idx)
                (push obj ulf-segments))
             ;; If we hit a read error, abort the loop.
-            (sb-int:simple-reader-error (hre) 
+            (sb-int:simple-reader-error (hre)
+              (declare (ignore hre))
               (format t "Hit a sb-int:simple-reader-error on string: ~s~%At start: ~s~%" 
                       str start)
               (setf start (length str)))))

--- a/test/composition.lisp
+++ b/test/composition.lisp
@@ -1,19 +1,25 @@
 ;;; Gene Louis Kim, 1-14-2020
 ;;; Unit tests for verifying the ulf-composition functions.
 
-(in-package :ulf-lib)
+(in-package :ulf-lib/tests)
 
-(setq *print-failures* t)
-(setq *print-errors* t)
-(setq *print-summary* t)
-(setq *summarize-results* t)
+;; Out-of-package versions of internal function calls.
+(defun extended-compose-type-string! (int1 int2)
+  (util:in-intern (int1 t1 :ulf-lib)
+    (util:inout-intern (int2 t2 :ulf-lib :callpkg :ulf-lib/tests)
+      (ulf-lib::extended-compose-type-string! t1 t2))))
+(defun left-right-compose-type-string! (int1 int2)
+  (util:in-intern (int1 t1 :ulf-lib)
+    (util:inout-intern (int2 t2 :ulf-lib :callpkg :ulf-lib/tests)
+      (ulf-lib::left-right-compose-type-string! t1 t2))))
+
 
 (defun semtype-str-equal (str1 str2)
   "Takes to string representations of semtypes and checks if they are equal,
   expanding out options into the same format."
-  (strict-semtype-equal
-    (extended-str2semtype str1)
-    (extended-str2semtype str2)))
+  (ulf-lib::strict-semtype-equal
+    (ulf-lib::extended-str2semtype str1)
+    (ulf-lib::extended-str2semtype str2)))
 
 (defun string-from-compose-types (ulf1 ulf2 &key (ext nil))
   "Takes two atomic ULF expressions, composes the types and returns the string

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,0 +1,42 @@
+(defpackage #:ulf-lib/tests
+  (:use #:cl #:lisp-unit #:ulf-lib)
+  (:export #:run))
+
+(in-package :ulf-lib/tests)
+
+(defun run (&key tests tags
+                 ;; lisp-unit verbosity parameters.
+                 (print-failures t)
+                 (print-errors t)
+                 (print-summary t)
+                 (summarize-results t))
+  "Run all tests.
+  
+  Optional arguments:
+    tests:  list of test names, defaults to running all tests
+    tags:   list of test tags
+
+  `tests` and `tags` should not both be set. The `tags` argument will be
+  ignored if that is the case.
+  "
+  (let ((*print-failures* print-failures)
+        (*print-errors* print-errors)
+        (*print-summary* print-summary)
+        (*summarize-results* summarize-results))
+    ;; Run tests.
+    (cond
+      ;; Specified tests.
+      (tests
+        (when tags
+          (warn (concatenate 'string
+                             "Both the :tags and :tests keyword "
+                             "arguments are given for ulf-lib/tests:run. "
+                             "Ignoring the :tags argument...")))
+        ; The cl-util dependency is available via the ulf-lib package.
+        (util:in-intern (tests pkgtests :ulf-lib/tests)
+          (lisp-unit:run-tests pkgtests :ulf-lib/tests)))
+      ;; Specified tags.
+      (tags (run-tags tags :ulf-lib/tests))
+      ;; Default, all tests.
+      (t (run-tests :all :ulf-lib/tests)))))
+

--- a/test/ttt-phrasal-patterns.lisp
+++ b/test/ttt-phrasal-patterns.lisp
@@ -1,12 +1,7 @@
 ;;; Gene Louis Kim, 3-17-2020
 ;;; Unit tests for verifying the ttt-phrasal-patterns functions.
 
-(in-package :ulf-lib)
-
-(setq *print-failures* t)
-(setq *print-errors* t)
-(setq *print-summary* t)
-(setq *summarize-results* t)
+(in-package :ulf-lib/tests)
 
 (define-test ttt-p-arg-mod
   "Tests for adding mod-a modifiers to p-arg."

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -64,11 +64,6 @@
       ("\\?" . "((S=>2)=>(S=>2))")
       )))
 
-;; Ensures that the input symbol is in ulf-lib.
-(defmacro in-ulf-lib ((x y) &body body)
-  `(util:in-intern (,x ,y :ulf-lib)
-                   ,@body))
-
 ;; Ensures that the input symbol is in *package*.
 (defmacro in-cur-package ((x y) &body body)
   `(util:in-intern (,x ,y *package*)

--- a/ttt-phrasal-patterns.lisp
+++ b/ttt-phrasal-patterns.lisp
@@ -7,11 +7,6 @@
 (defmacro inout-ulf-lib ((x y &key (callpkg nil)) &body body)
   `(util:inout-intern (,x ,y :ulf-lib :callpkg ,callpkg)
                       ,@body))
-;; Ensures that the input symbol is in ulf-lib.
-(defmacro in-ulf-lib ((x y) &body body)
-  `(util:in-intern (,x ,y :ulf-lib)
-                   ,@body))
-
 
 (defparameter *ttt-noun*
   '(! lex-noun?

--- a/ulf-lib.asd
+++ b/ulf-lib.asd
@@ -4,6 +4,7 @@
 (asdf:defsystem :ulf-lib
   :depends-on (:ttt :cl-strings :cl-ppcre :cl-util :lisp-unit)
   :components ((:file "package")
+               (:file "util")
                (:file "suffix")
                (:file "semtype")
                (:file "ttt-lexical-patterns")
@@ -12,6 +13,11 @@
                (:file "search")
                (:file "macro")
                (:file "preprocess")
-               (:file "composition")
-               ))
+               (:file "composition"))
+  :around-compile (lambda (next)
+                    ; For debugging/development.
+                    (proclaim '(optimize (debug 3) (safety 3) (space 1) (speed 1)))
+                    ; For production.
+                    ;(proclaim '(optimize (debug 0) (safety 1) (space 1) (speed 3)))
+                    (funcall next)))
 

--- a/ulf-lib.asd
+++ b/ulf-lib.asd
@@ -1,8 +1,12 @@
 ;; ULF Inferface and Manipulation Library.
-;; Started ~2018-11-19
-
 (asdf:defsystem :ulf-lib
-  :depends-on (:ttt :cl-strings :cl-ppcre :cl-util :lisp-unit)
+  :name "Episodic Logic-Unscoped Logical Form (ULF) Interface and Manipulation Library"
+  :serial t
+  :version "1.0.0"
+  :description "A library for basic interfacing and manipulations of Episodic logic, unscoped logical formulas (ULFs)."
+  :author "Gene Louis Kim <gkim21@cs.rochester.edu>"
+  :license "MIT"
+  :depends-on (:ttt :cl-strings :cl-ppcre :cl-util)
   :components ((:file "package")
                (:file "util")
                (:file "suffix")
@@ -19,5 +23,17 @@
                     (proclaim '(optimize (debug 3) (safety 3) (space 1) (speed 1)))
                     ; For production.
                     ;(proclaim '(optimize (debug 0) (safety 1) (space 1) (speed 3)))
-                    (funcall next)))
+                    (funcall next))
+  :in-order-to ((test-op (test-op :ulf-lib/tests))))
+
+(asdf:defsystem :ulf-lib/tests
+  :serial t
+  :description "Tests for the ULF-LIB library"
+  :author "Gene Louis Kim <gkim21@cs.rochester.edu>"
+  :license "MIT"
+  :depends-on (:ulf-lib :lisp-unit)
+  :components ((:file "test/package")
+               (:file "test/composition")
+               (:file "test/ttt-phrasal-patterns"))
+  :perform (test-op (o c) (symbol-call :ulf-lib/tests :run)))
 

--- a/util.lisp
+++ b/util.lisp
@@ -1,0 +1,8 @@
+
+(in-package :ulf-lib)
+
+;; Ensures that the input symbol is in ulf-lib.
+(defmacro in-ulf-lib ((x y) &body body)
+  `(util:in-intern (,x ,y :ulf-lib)
+                   ,@body))
+


### PR DESCRIPTION
Clean up code and modify some optimization declarations/proclamations to eliminate build warnings. Also package the tests for easier testing while modifying the code.