### PR TITLE
Sampling extension

### DIFF
--- a/composition.lisp
+++ b/composition.lisp
@@ -2,16 +2,16 @@
 
 (in-package :ulf-lib)
 
-(defun merge-suffixes (op arg)
-  "Compute the suffix for the result of running operator `op` on `arg`. Range
-  of `op` is the preferred. If unspecified, use the argument (or domain if that
+(defun merge-suffixes (opr arg)
+  "Compute the suffix for the result of running operator `opr` on `arg`. Range
+  of `opr` is the preferred. If unspecified, use the argument (or domain if that
   is unspecified) for >> connective. Use the whole operator suffix for =>
   connective."
   (let*
-    ((ran-suffix (suffix (range op)))
-     (dom-suffix (suffix (domain op)))
+    ((ran-suffix (suffix (range opr)))
+     (dom-suffix (suffix (domain opr)))
      (arg-suffix (suffix arg))
-     (opr-suffix (suffix op))
+     (opr-suffix (suffix opr))
 
      (ran-chars (if (null ran-suffix) nil (coerce (symbol-name ran-suffix) 'list)))
      (dom-chars (if (null dom-suffix) nil (coerce (symbol-name dom-suffix) 'list)))
@@ -24,11 +24,11 @@
        (cond
          ((intersection poses ran-chars)
           (find-if pos-find-fn ran-chars))
-         ((equal ">>" (symbol-name (connective op)))
+         ((equal ">>" (symbol-name (connective opr)))
           (if (intersection poses arg-chars)
             (find-if pos-find-fn arg-chars)
             (find-if pos-find-fn dom-chars)))
-         ((equal "=>" (symbol-name (connective op)))
+         ((equal "=>" (symbol-name (connective opr)))
           (find-if pos-find-fn opr-chars))))
 
      (filtered (remove-if #'null (list new-val))))
@@ -56,8 +56,8 @@
 
 ;; Compose a given operator and argument if possible.
 ;; Assumption (for now): Arg has no exponent. If it does, it is ignored.
-;; suffixes are propagated from op.
-;; Synfeats are propagated from op if => and arg if >> with
+;; suffixes are propagated from opr.
+;; Synfeats are propagated from opr if => and arg if >> with
 ;; exceptions per synfeat.
 ;; type-params are propagated from both.
 (declaim (ftype (function (semtype) fixnum) ex))
@@ -96,7 +96,7 @@
             ;; recognize whether the sentence is grammatical (top-predicate is
             ;; a verb).
             (when (not (atomic-type-p result))
-              (set-suffix result (merge-suffixes op arg)))
+              (set-suffix result (merge-suffixes opr arg)))
             ;; Update syntactic features.
             (when (not ignore-synfeats)
               (set-synfeats result (compose-synfeats! opr arg)))

--- a/semtype.lisp
+++ b/semtype.lisp
@@ -332,7 +332,7 @@
 ;; If :ignore-exp is 'r then ignore exponents recursively
 ;;
 ;; For options, checks if there is a single compatible match.
-;; For suffixes, if both have  suffix specification, checks for equality
+;; For suffixes, if both have suffix specification, checks for equality
 ;;   otherwise doesn't care.
 ;; For synfeats, call syntactic-features-match? with x as the pattern.
 (defun semtype-match? (raw-x raw-y &key ignore-exp)
@@ -566,7 +566,8 @@
     ((new-types
        ;; Flatten, overwrite synfeats, and create new type.
        (loop for st in (types (flatten-options base-semtype))
-             for copy-st = (copy-semtype st)
+             for copy-st = (copy-semtype
+                             st :c-synfeats (copy *default-syntactic-features*))
              for new-synfeat = (update-syntactic-features (synfeats copy-st)
                                                           new-synfeats)
              collect (new-semtype st copy-st 1 nil

--- a/semtype.lisp
+++ b/semtype.lisp
@@ -45,7 +45,6 @@
 ;; 2. ! prefix for any feature for the negation
 ;;
 
-;; TODO Write a class for each syntactic feature which specifies how it propagates in function applications, with defaults written as above. Special propagation examples include: *h, which should default to empty, but propagate through everything (or just use the type param for this?) 
 ;; TODO Make sure *h and *p can have duplicates, or have counts.
 
 ;; Class representing a ULF semantic type
@@ -197,7 +196,6 @@
   ;; compiler note
   ;;  note: can't open-code test of unknown type SEMTYPE
   (declare (ftype (function (t) fixnum) ex))
-  ; TODO: add a parameter for the package.
   (when (or (symbolp dom) (listp dom))
     (setf dom (intern-symbols-recursive dom :ulf-lib)))
   (when (or (symbolp ran) (listp ran))
@@ -327,23 +325,16 @@
       (t
         st))))
 
-;; Check if two semantic types are equal. If one of the types is an optional
-;; type then return true if either of the two options match. If both types are
-;; optional their intersection must not be empty.
+
+;; Check if y matches with the semantic type pattern x. If one of the types is
+;; an optional type then return true if any option-pair matches.
 ;; If :ignore-exp is not NIL then exponents of the two types aren't checked
 ;; If :ignore-exp is 'r then ignore exponents recursively
-;; Tenses and suffixes are checked if both types have a specified
-;; tense/suffix.
-;; Tenses and suffixes on optionals are ignored.
 ;;
-;; TODO(gene): see note below
-;; Note: This function is more of a "compatibility checker" than a function to
-;; check actual equality. I'll probably rename this to something better later.
 ;; For options, checks if there is a single compatible match.
-;; For suffixes, if there are suffixes, checks for equality otherwise doesn't care.
+;; For suffixes, if both have  suffix specification, checks for equality
+;;   otherwise doesn't care.
 ;; For synfeats, call syntactic-features-match? with x as the pattern.
-;; Basically, x is the general class and we check if y has an option that is a
-;; subset of one of the x options.
 (defun semtype-match? (raw-x raw-y &key ignore-exp)
   (declare (ftype (function (t) fixnum) ex))
   ;; Expand out one level of exponents if relevant.
@@ -392,7 +383,6 @@
 ;; Keyword options where nil is a specific value (e.g. false) a keyword symbol
 ;; :null is used to indicate no value provided, which defaults to using the
 ;; source semtype value.
-;; TODO: use :null for default values everywhere
 (defun copy-semtype (x &key c-dom c-ran c-ex
                        (c-suffix :null)
                        (c-types :null)

--- a/semtype.lisp
+++ b/semtype.lisp
@@ -439,7 +439,7 @@
       (return-from semtype2str nil))
     (let ((type-params-str
             (format nil "[~a]"
-                    (str:join "," (mapcar #'semtype2str (type-params s)))))
+                    (str:join ";" (mapcar #'semtype2str (type-params s)))))
           ;; Synfeats without the macro dispatch symbol.
           (synfeat-str (str:concat
                          (if (suffix s)
@@ -520,8 +520,8 @@
 
 (defun split-type-param-str (tpstr)
   "Splits a type param list string into the individual type strings.
-   These are comma separated, but since the types are recursively defined, only
-   split on commas that are at the top-level square bracketing."
+   These are semi-colon separated, but since the types are recursively defined,
+   only split on semi-colons that are at the top-level square bracketing."
   (declare (type (or simple-string null) tpstr))
   (when (null tpstr)
     (return-from split-type-param-str nil))
@@ -532,8 +532,8 @@
              (type fixnum bracket-depth))
     (loop for c across tpstr do
           (cond
-            ; Comma at top-level, add word and reset cur-chars.
-            ((and (eql c #\,) (= bracket-depth 0))
+            ; Semi-colon at top-level, add word and reset cur-chars.
+            ((and (eql c #\;) (= bracket-depth 0))
              (push (coerce (reverse cur-chars) 'string) params)
              (setf cur-chars nil))
             ; Open bracket, add depth.

--- a/semtype.lisp
+++ b/semtype.lisp
@@ -5,7 +5,8 @@
 ;; Maximum semtype exponent for variable values.
 ;; e.g. D^n=>2 can be generated as 2, (D=>2), (D=>(D=>2)), etc. until the
 ;; maximum number.
-(defparameter *semtype-max-exponent* 5)
+;; TODO: write functions to reload in parameters (e.g. *semtypes*, etc.) after setting this so that it gets propagated properly.
+(defparameter *semtype-max-exponent* 3)
 
 
 ;; A MORE COMPACT REPRESENTATIONS
@@ -132,12 +133,12 @@
     (t (setf (type-params semtype) (append (type-params semtype) type-params)))))
 
 (defmethod set-suffix ((obj semtype) suf)
-  "Adds suffix to a semtype. Recurses into optional-type since it doesn't
+  "Sets the suffix to a semtype. Recurses into optional-type since it doesn't
    directly carry suffixes. Ignored if called on an atomic type."
   (cond
     ((optional-type-p obj)
      (mapcar #'(lambda (child) (set-suffix child suf)) (types obj)))
-    ((atomic-type-p obj)
+    ((and (atomic-type-p obj) (not (null suf)))
      (warn "Atomic semtypes cannot take suffixes."))
     (t
      (setf (suffix obj) suf))))

--- a/syntactic-features/feature-definition-definitions.lisp
+++ b/syntactic-features/feature-definition-definitions.lisp
@@ -31,14 +31,20 @@
         (new-optional-semtype (list *sentence-semtype*
                                     *predicate-semtype*))))
 (setf (fdefinition 'auxiliary-combinator-fn)
-      (base-result-pattern-combinator-generator *predicate-semtype*))
+      (base-result-pattern-combinator-generator
+        (new-optional-semtype (list *sentence-semtype*
+                                    *predicate-semtype*))))
+(setf (fdefinition 'perfect-combinator-fn)
+      (base-result-pattern-combinator-generator
+        (new-optional-semtype (list *sentence-semtype*
+                                    *predicate-semtype*))))
+(setf (fdefinition 'progressive-combinator-fn)
+      (base-result-pattern-combinator-generator
+        (new-optional-semtype (list *sentence-semtype*
+                                    *predicate-semtype*))))
 (setf (fdefinition 'plurality-combinator-fn)
       (base-result-pattern-combinator-generator *predicate-semtype*))
-(setf (fdefinition 'perfect-combinator-fn)
-      (base-result-pattern-combinator-generator *predicate-semtype*))
 (setf (fdefinition 'passive-combinator-fn)
-      (base-result-pattern-combinator-generator *predicate-semtype*))
-(setf (fdefinition 'progressive-combinator-fn)
       (base-result-pattern-combinator-generator *predicate-semtype*))
 (defun lexical-combinator-fn (base opr arg csq &optional opr-semtype arg-semtype)
   "We always lose lexicality unless specified in the type."

--- a/syntactic-features/syntactic-features.lisp
+++ b/syntactic-features/syntactic-features.lisp
@@ -124,6 +124,16 @@
   ;; Return the modified object.
   obj)
 
+(defmethod add-feature-value ((obj syntactic-features) new-feature)
+  "Same as add-feature-values but with a single value."
+  (add-feature-values obj (list new-features)))
+
+(defmethod del-feature-value ((obj syntactic-features) key)
+  "Deletes the given feature value for the given key. Returns the object."
+  (setf (feature-map obj)
+        (remove-if #'(lambda (cell) (equal (car cell) key)) (feature-map obj)))
+  obj)
+
 (defmethod update-feature-map ((obj syntactic-features) (new-feature-map list))
   "Takes a new feature map and updates the old one to include all of the
   entries in the new one. Any feature names that are not specified in

--- a/syntactic-features/syntactic-features.lisp
+++ b/syntactic-features/syntactic-features.lisp
@@ -10,7 +10,6 @@
      :initarg :feature-map
      :accessor feature-map)))
 
-;; TODO: compile this from default feature values for each feature.
 (defparameter *default-syntactic-features*
   (make-instance 'syntactic-features
                  :feature-map nil))
@@ -210,4 +209,31 @@
     (update-feature-map with-combs
                         (remove-if #'(lambda (pair) (null (cdr pair)))
                                    (feature-map csq-feats)))))
+
+(defmethod feature-map-difference ((base-feats syntactic-features)
+                                   (diff-feats syntactic-features))
+  "Creates a new syntactic-features object which is the same as base-feats but
+  all entries with the keys in diff-feats removed (set to null)."
+  (let ((result (copy base-feats)))
+    (loop for key in (mapcar #'car (feature-map diff-feats))
+          if (assoc key (feature-map result))
+          do (setf (cdr (assoc key (feature-map result))) nil))
+    result))
+
+(defmethod feature-map-union ((one-feats syntactic-features)
+                              (two-feats syntactic-features))
+  "Creates a new syntactic-features object which adds two-feats entries to
+  one-feats. Which of the two are selected in the case of both being present is
+  undefined."
+  (let ((result (copy one-feats)))
+    (loop for (key . value) in (feature-map two-feats)
+          if (and (assoc key (feature-map result))
+                  (not (assoc key (feature-map result))))
+          do (setf (cdr (assoc key (feature-map result)))
+                   value)
+          else if (not (assoc key (feature-map result)))
+          do (setf (feature-map result)
+                   (cons (cons key value)
+                         (feature-map result))))
+    result))
 

--- a/test/composition.lisp
+++ b/test/composition.lisp
@@ -47,7 +47,7 @@
   (assert-equal nil (string-from-compose-types 'the.d 'the.d))
   (assert-equality
     #'semtype-equal?-str
-    "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+    "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^4=>(D=>(S=>2)))_V}}}}}"
     (string-from-compose-types 'help.v 'me.pro))
   (assert-equal nil (string-from-compose-types 'be.v 'me.pro))
   (assert-equal "(D=>(S=>2))_V" (string-from-compose-types 'be.v 'happy.a)))
@@ -58,7 +58,7 @@
   ; tense
   (assert-equality
     #'semtype-equal?-str
-    "{(D=>(S=>2))_V%T|{{(D=>(D=>(S=>2)))_V%T|((D=>(S=>2))=>(D=>(S=>2)))_V%T}|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V%T|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V%T|{({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V%T|({D|(D=>(S=>2))}^5=>(D=>(S=>2)))_V%T}}}}}"
+    "{(D=>(S=>2))_V%T|{{(D=>(D=>(S=>2)))_V%T|((D=>(S=>2))%!T,!PF,!PG,!PV,!X=>(D=>(S=>2)))_V%T}|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V%T|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V%T|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V%T|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^5=>(D=>(S=>2)))_V%T}}}}}"
     (string-from-compose-types 'pres 'run.v :ext 'extended))
   (assert-equal nil (string-from-compose-types 'past 'happy.a :ext 'extended))
   (assert-equal nil (string-from-compose-types 'cf 'man.n :ext 'extended))
@@ -80,11 +80,11 @@
   (assert-equal nil (string-from-compose-types 'qt-attr 'her.pro :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V[*QT]}}}}}"
+    "{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V[*QT]}}}}}"
     (string-from-compose-types 'say.v '*qt :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "QT-ATTR1[{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{{(D=>(D=>(S=>2)))_V[*QT]|((D=>(S=>2))=>(D=>(S=>2)))_V[*QT]}|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V[*QT]}}}}}]"
+    "QT-ATTR1[{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{{(D=>(D=>(S=>2)))_V[*QT]|((D=>(S=>2))%!T,!PF,!PG,!PV,!X=>(D=>(S=>2)))_V[*QT]}|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V[*QT]}}}}}]"
     (string-from-compose-types 'qt-attr '(say.v *qt) :ext 'extended))
   ; 's
   (assert-equality
@@ -120,14 +120,14 @@
   ;; (\" (yes! (qt-attr (say.v *qt))) \")   qt-attr2[T1[*qt]] + \" >> T1
   (assert-equal "\"" (ulf-type-string? '\"))
   (assert-equal "D[*QT]" (ulf-type-string? '*qt))
-  (assert-equal "(D=>(S=>2))[*QT]" (string-from-compose-types '= '*qt :ext 'extended))
-  (assert-equal "QT-ATTR1[(D=>(S=>2))[*QT]]"
+  (assert-equal "{(D=>(S=>2))_A[*QT]|(D=>(S=>2))_P[*QT]}" (string-from-compose-types '= '*qt :ext 'extended))
+  (assert-equal "QT-ATTR1[{(D=>(S=>2))_A[*QT]|(D=>(S=>2))_P[*QT]}]"
                 (string-from-compose-types 'qt-attr '(= *qt) :ext 'extended))
-  (assert-equal "D[QT-ATTR1[(D=>(S=>2))[*QT]]]"
+  (assert-equal "D[QT-ATTR1[{(D=>(S=>2))_A[*QT]|(D=>(S=>2))_P[*QT]}]]"
                 (string-from-compose-types '(qt-attr (= *qt)) 'it.pro :ext 'extended))
-  (assert-equal "QT-ATTR2[(D=>(S=>2))[*QT]]"
+  (assert-equal "QT-ATTR2[{(D=>(S=>2))_A[*QT]|(D=>(S=>2))_P[*QT]}]"
                 (string-from-compose-types '\" '((qt-attr (= *qt)) it.pro) :ext 'extended))
-  (assert-equal "(D=>(S=>2))"
+  (assert-equal "{(D=>(S=>2))_A|(D=>(S=>2))_P}"
                 (string-from-compose-types (list '|"| '((qt-attr (= *qt)) it.pro)) '|"|
                                            :ext 'extended)))
 
@@ -173,11 +173,11 @@
     (string-from-compose-types 'as.p-arg 'chicken.n :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+    "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V}}}}}"
     (string-from-compose-types 'sleep.v '(in.p-arg that.pro) :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}"
+    "{(D=>(S=>2))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V}}}}"
     (string-from-compose-types 'dress.v '(as.p-arg chicken.n) :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
@@ -239,7 +239,7 @@
                   (ulf-type-string? 'he.pro) (ulf-type-string? 'run))
     (assert-equality
       #'semtype-equal?-str
-      "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+      "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V}}}}}"
       typestr))
   (multiple-value-bind
     (typestr dir original)
@@ -249,7 +249,7 @@
                   (ulf-type-string? 'he.pro) (ulf-type-string? 'run))
     (assert-equality
       #'semtype-equal?-str
-      "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+      "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V}}}}}"
       typestr))
   (multiple-value-bind
     (typestr dir original)

--- a/test/composition.lisp
+++ b/test/composition.lisp
@@ -216,15 +216,19 @@
     (string-from-compose-types '? '(i.pro ((past go.v) there.pro)) :ext 'extended)))
 
 (define-test comp-p-arg-mod
-  "Tests for adding mod-a modifiers to p-arg."
+  "Tests for adding mod-a modifiers to prepositional phrases."
   (:tag :comp-p-arg-mod)
   ; NB(gene): I'm not sure we want this. Instead we should just use
   ; right.adv-s. *.ps are very much not adjective-like. Perhaps we could use
   ; right.mod-p when we introduce it.
   (assert-equality
     #'semtype-equal?-str
-    "((S=>2)>>(S=>2))"
+    "((S=>2)_v>>(S=>2))_p"
     (string-from-compose-types 'right.mod-a '(before.ps (i.pro ((past move.v) it.pro)))))
+  (assert-equality
+    #'semtype-equal?-str
+    "((S=>2)_v>>(S=>2))_p"
+    (string-from-compose-types '(mod-a right.a) '(before.ps (i.pro ((past move.v) it.pro)))))
   (assert-equal nil
     (string-from-compose-types 'right.mod-n '(before.ps (i.pro ((past move.v) it.pro))))))
 

--- a/test/composition.lisp
+++ b/test/composition.lisp
@@ -354,3 +354,8 @@
   (assert-equal "{((D=>(S=>2))_N=>D)%LEX|((D=>(S=>2))_P=>D)%LEX}"
                 (ulf-type-string? 'a.d)))
 
+(define-test ulf-type-string?-named-predicates
+  (:tag :ulf-type-string?)
+  (assert-equal "{(D=>(S=>2))_A%LEX|(D=>(D=>(S=>2)))_A%LEX}" (ulf-type-string? '19.a))
+  (assert-equal "(D=>(S=>2))_N%LEX" (ulf-type-string? '|Man|.n)))
+

--- a/test/composition.lisp
+++ b/test/composition.lisp
@@ -84,7 +84,7 @@
     (string-from-compose-types 'say.v '*qt :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "QT-ATTR1[{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{{(D=>(D=>(S=>2)))_V[*QT]|((D=>(S=>2))%!T,!PF,!PG,!PV,!X=>(D=>(S=>2)))_V[*QT]}|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V[*QT]}}}}}]"
+    "QT-ATTR1[{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{(D=>(D=>(S=>2)))_V[*QT]|{((D=>(S=>2))%!T,!PF,!PG,!PV,!X=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))%!T,!PF,!PG,!PV,!X}^4=>(D=>(S=>2)))_V[*QT]}}}}}}]"
     (string-from-compose-types 'qt-attr '(say.v *qt) :ext 'extended))
   ; 's
   (assert-equality

--- a/test/composition.lisp
+++ b/test/composition.lisp
@@ -47,7 +47,7 @@
   (assert-equal nil (string-from-compose-types 'the.d 'the.d))
   (assert-equality
     #'semtype-equal?-str
-    "{(S=>2)|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+    "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
     (string-from-compose-types 'help.v 'me.pro))
   (assert-equal nil (string-from-compose-types 'be.v 'me.pro))
   (assert-equal "(D=>(S=>2))_V" (string-from-compose-types 'be.v 'happy.a)))
@@ -80,11 +80,11 @@
   (assert-equal nil (string-from-compose-types 'qt-attr 'her.pro :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "{(S=>2)[*QT]|{(D=>(S=>2))_V[*QT]|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V[*QT]}}}}}"
+    "{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V[*QT]}}}}}"
     (string-from-compose-types 'say.v '*qt :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "QT-ATTR1[{(S=>2)[*QT]|{(D=>(S=>2))_V[*QT]|{{(D=>(D=>(S=>2)))_V[*QT]|((D=>(S=>2))=>(D=>(S=>2)))_V[*QT]}|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V[*QT]}}}}}]"
+    "QT-ATTR1[{(S=>2)_V[*QT]|{(D=>(S=>2))_V[*QT]|{{(D=>(D=>(S=>2)))_V[*QT]|((D=>(S=>2))=>(D=>(S=>2)))_V[*QT]}|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V[*QT]|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V[*QT]|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V[*QT]}}}}}]"
     (string-from-compose-types 'qt-attr '(say.v *qt) :ext 'extended))
   ; 's
   (assert-equality
@@ -173,7 +173,7 @@
     (string-from-compose-types 'as.p-arg 'chicken.n :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "{(S=>2)|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+    "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
     (string-from-compose-types 'sleep.v '(in.p-arg that.pro) :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
@@ -196,23 +196,23 @@
 (define-test sentential-punctuation-compose
   "Tests for ! and ?."
   (:tag :sentential-punctuation-compose)
-  (assert-equal "((S=>2)>>(S=>2))%LEX" (ulf-type-string? '!))
-  (assert-equal "((S=>2)>>(S=>2))%LEX" (ulf-type-string? '?))
+  (assert-equal "((S=>2)_V>>(S=>2))%LEX" (ulf-type-string? '!))
+  (assert-equal "((S=>2)_V>>(S=>2))%LEX" (ulf-type-string? '?))
   (assert-equality
     #'semtype-equal?-str
-    "(S=>2)"
+    "(S=>2)_v"
     (string-from-compose-types '(i.pro (go.v there.pro)) '! :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "(S=>2)"
+    "(S=>2)_v"
     (string-from-compose-types '(i.pro (go.v there.pro)) '? :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "(S=>2)%T"
+    "(S=>2)_v%T"
     (string-from-compose-types '! '(i.pro ((past go.v) there.pro)) :ext 'extended))
   (assert-equality
     #'semtype-equal?-str
-    "(S=>2)%T"
+    "(S=>2)_v%T"
     (string-from-compose-types '? '(i.pro ((past go.v) there.pro)) :ext 'extended)))
 
 (define-test comp-p-arg-mod
@@ -239,7 +239,7 @@
                   (ulf-type-string? 'he.pro) (ulf-type-string? 'run))
     (assert-equality
       #'semtype-equal?-str
-      "{(S=>2)|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+      "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
       typestr))
   (multiple-value-bind
     (typestr dir original)
@@ -249,7 +249,7 @@
                   (ulf-type-string? 'he.pro) (ulf-type-string? 'run))
     (assert-equality
       #'semtype-equal?-str
-      "{(S=>2)|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
+      "{(S=>2)_V|{(D=>(S=>2))_V|{({D|(D=>(S=>2))}=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^2=>(D=>(S=>2)))_V|{({D|(D=>(S=>2))}^3=>(D=>(S=>2)))_V|({D|(D=>(S=>2))}^4=>(D=>(S=>2)))_V}}}}}"
       typestr))
   (multiple-value-bind
     (typestr dir original)
@@ -257,23 +257,23 @@
     (declare (ignore original))
     (assert-equal "right" dir
                   (ulf-type-string? 'it.pro) (ulf-type-string? '((pres do.aux-s) see.v)))
-    (assert-equality #'semtype-equal?-str "(S=>2)%T" typestr))
+    (assert-equality #'semtype-equal?-str "(S=>2)_V%T" typestr))
   (multiple-value-bind
     (typestr dir original)
     (string-from-compose-types 'it.pro '((pres do.aux-s) see.v) :ext 'extended)
     (declare (ignore original))
     (assert-equal "left" dir
                   (ulf-type-string? 'it.pro) (ulf-type-string? '((pres do.aux-s) see.v)))
-    (assert-equality #'semtype-equal?-str "(S=>2)%T" typestr)))
+    (assert-equality #'semtype-equal?-str "(S=>2)_V%T" typestr)))
 
 
 (define-test free-sent-mod
   (:tag :free-sent-mod :left-right)
-  (assert-equality #'semtype-equal?-str "((S=>2)>>(S=>2))%lex" (ulf-type-string? 'not))
-  (assert-equality #'semtype-equal?-str "((S=>2)>>(S=>2))%lex" (ulf-type-string? 'not.adv-s))
-  (assert-equality #'semtype-equal?-str "((S=>2)>>(S=>2))%lex" (ulf-type-string? 'always.adv-f))
-  (assert-equality #'semtype-equal?-str "((S=>2)>>(S=>2))%lex" (ulf-type-string? 'today.adv-e))
-  (assert-equality #'semtype-equal?-str "((S=>2)>>(S=>2))" (ulf-type-string? '(when.ps (i.pro (past sleep.v)))))
+  (assert-equality #'semtype-equal?-str "((S=>2)_v>>(S=>2))%lex" (ulf-type-string? 'not))
+  (assert-equality #'semtype-equal?-str "((S=>2)_v>>(S=>2))%lex" (ulf-type-string? 'not.adv-s))
+  (assert-equality #'semtype-equal?-str "((S=>2)_v>>(S=>2))%lex" (ulf-type-string? 'always.adv-f))
+  (assert-equality #'semtype-equal?-str "((S=>2)_v>>(S=>2))%lex" (ulf-type-string? 'today.adv-e))
+  (assert-equality #'semtype-match?-str "((S=>2)_v>>(S=>2))" (ulf-type-string? '(when.ps (i.pro (past sleep.v)))))
   (let ((ulf-segments
           '(he.pro
              run.v
@@ -317,14 +317,14 @@
   (:tag :itaux :left-right)
   (assert-equality
     #'semtype-equal?-str
-    "((D=>(S=>2))_V%!T,!X>>(S=>2)%T)"
+    "((D=>(S=>2))_V%!T,!X>>(S=>2)_v%T)"
     (string-from-compose-types '(past do.aux-s) 'him.pro))
   ; TODO(gene): write a generalization of ulf-type? for left-right type.
   ; for now, we will just bypass it under the assumption that the test above
   ; this one passed.
   (assert-equality
     #'semtype-equal?-str
-    "(S=>2)%T"
+    "(S=>2)_v%T"
     (string-from-compose-types '((past do.aux-s) he.pro) 'run.v))
   (assert-equal nil (string-from-compose-types
                       '(past do.aux-s) 'dog.n

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -146,8 +146,10 @@
 ;; Check if *x* has the *suffix* extension.
 ;; Allows it to be square-bracketed from TTT operator hiding.
 (defun suffix-check (x suffix)
-  (re:all-matches (concatenate 'string "^\\[?\\|? ?\\{?\(\\w\|\\d\|-\|\/\|:\|\\.\|\\*\|\\[\|\\]\)\+\\}?\\." suffix "\\|?\\]?$")
-            (format nil "~s" x)))
+  (re:scan
+    (concatenate 'string "^\\[?\\|? ?\\{?\(\\w\|\\d\|-\|\/\|:\|\\.\|\\*\|\\[\|\\]\)\+\\}?\\." suffix "\\|?\\]?$")
+    (format nil "~s" x)))
+(gute:memoize 'suffix-check)
 
 (defun in-ulf-lib-suffix-check (x suffix)
   (in-intern (x y :ulf-lib)

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -44,8 +44,8 @@
           ;;; Either takes two tensed sentences to make a new tensed sentence or two
           ;;; untensed sentence and makes a new untensed sentence.
           ;("{S}\\.PS" . "{((S=>2)_T=>((S=>2)_T=>(S=>2)_T))|((S=>2)_!T=>((S=>2)_!T=>(S=>2)_!T))}")
-          ("{S}\\.N" . "(D=>(S=>2))_n%lex")
-          ("{S}-OF\\.N" . "(D=>(D=>(S=>2)))_n%lex")
+          ("{S}\\.N" . "(D=>(S=>2))_n%lex,!pl")
+          ("{S}-OF\\.N" . "(D=>(D=>(S=>2)))_n%lex,!pl")
           ("{S}\\.A" . "{(D=>(S=>2))_a%lex|(D=>(D=>(S=>2)))_a%lex}")
           ; Note: "be.v" is intentionally placed above "*.v" so that it gets mapped correctly.
           ; Be careful while moving this around so that "be.v" is mapped correctly.
@@ -54,8 +54,8 @@
           ;   plurals: must be in a kind, (be.v (= (k (plur lawyer.n))))
           ;   perfect, progressive, auxiliary: aspectual operators operate over verbs
           ;   passive: 'be' is an empty auxiliary acting as part of the passive
-          ("BE\\.V" . "({(D=>(S=>2))_A|(D=>(S=>2))_P}=>(D=>(S=>2)))_v%lex")
-          ("{S}\\.V" . "({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(S=>2)))_v%lex")
+          ("BE\\.V" . "({(D=>(S=>2))_A|(D=>(S=>2))_P}=>(D=>(S=>2)))_v%lex,!t")
+          ("{S}\\.V" . "({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(S=>2)))_v%lex,!t")
           ("{S}\\.D" . "({(D=>(S=>2))_n|(D=>(S=>2))_p}=>D)%lex")
           ("{S}\\.ADV-A" . "((D=>(S=>2))_v>>(D=>(S=>2))_v)%lex")
           ("{S}\\.(ADV-E|ADV-S|ADV-F)" . "((S=>2)_v>>(S=>2))%lex")

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -49,7 +49,12 @@
           ("{S}\\.A" . "{(D=>(S=>2))_a|(D=>(D=>(S=>2)))_a}%lex")
           ; Note: "be.v" is intentionally placed above "*.v" so that it gets mapped correctly.
           ; Be careful while moving this around so that "be.v" is mapped correctly.
-          ("BE\\.V" . "((D=>(S=>2))=>(D=>(S=>2)))_v%lex")
+          ; "be.v" can't take plural, perfect, progressive, passive, or
+          ; auxiliary featuring predicates.
+          ;   plurals: must be in a kind, (be.v (= (k (plur lawyer.n))))
+          ;   perfect, progressive, auxiliary: aspectual operators operate over verbs
+          ;   passive: 'be' is an empty auxiliary acting as part of the passive
+          ("BE\\.V" . "((D=>(S=>2))%!t,!pl,!pf,!pg,!pv,!x=>(D=>(S=>2)))_v%lex")
           ("{S}\\.V" . "({D|(D=>(S=>2))}^n=>(D=>(S=>2)))_v%lex")
           ("{S}\\.D" . "({(D=>(S=>2))_n|(D=>(S=>2))_p}=>D)%lex")
           ("{S}\\.ADV-A" . "((D=>(S=>2))_v>>(D=>(S=>2))_v)%lex")
@@ -91,7 +96,7 @@
                              :options
                              (append
                                ;; verbs.
-                               (list (str2semtype "(({D|(D=>(S=>2))}^n=>(D=>(S=>2)))_V%!T%>T)"))
+                               (list (str2semtype "(({D|(D=>(S=>2))}^n=>(D=>(S=>2)))_V%!T,LEX%>T)"))
                                ;; Auxiliaries and aspectual operators (prog/perf)
                                ;; Tense will take an aspectual operator and then
                                ;; return the same type except that the range is

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -286,7 +286,8 @@
   (in-intern (x s *package*)
     (let* ((sstr (if (not (stringp s)) (atom2str s) s))
            (chars (coerce sstr 'list)))
-      (and (> (length chars) 1)
+      (and (not (equal "|'S|" sstr))
+           (> (length chars) 1)
            (eql #\| (nth 0 chars))
            (eql #\| (nth (1- (length chars)) chars))))))
 

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -54,14 +54,14 @@
           ;   plurals: must be in a kind, (be.v (= (k (plur lawyer.n))))
           ;   perfect, progressive, auxiliary: aspectual operators operate over verbs
           ;   passive: 'be' is an empty auxiliary acting as part of the passive
-          ("BE\\.V" . "((D=>(S=>2))%!t,!pl,!pf,!pg,!pv,!x=>(D=>(S=>2)))_v%lex")
-          ("{S}\\.V" . "({D|(D=>(S=>2))}^n=>(D=>(S=>2)))_v%lex")
+          ("BE\\.V" . "({(D=>(S=>2))_A|(D=>(S=>2))_P}=>(D=>(S=>2)))_v%lex")
+          ("{S}\\.V" . "({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(S=>2)))_v%lex")
           ("{S}\\.D" . "({(D=>(S=>2))_n|(D=>(S=>2))_p}=>D)%lex")
           ("{S}\\.ADV-A" . "((D=>(S=>2))_v>>(D=>(S=>2))_v)%lex")
           ("{S}\\.(ADV-E|ADV-S|ADV-F)" . "((S=>2)_v>>(S=>2))%lex")
           ("PLUR" . "((D=>(S=>2))_n%!pl>>(D=>(S=>2))_n%pl)")
           ("K" . "((D=>(S=>2))_n=>D)")
-          ("TO|KA" . "((D=>(S=>2))_v%!t=>D)")
+          ("TO|KA" . "((D=>(S=>2))_v%!t,!x=>D)")
           ("KE" . "((S=>2)_v%!t=>D)")
           ("THAT" . "((S=>2)_v%t=>D)%lex")
           ("WHETHER|ANS-TO" . "((S=>2)_v%t=>D)%lex")
@@ -70,8 +70,8 @@
           ("FQUAN|NQUAN" . "((D=>(S=>2))_a=>((D=>(S=>2))_n=>D))")
           ("SET-OF" . "(D^n=>(D=>(D=>D)))")
           ("NOT" . "((S=>2)_v>>(S=>2))%lex")
-          ("=" . "(D=>(D=>(S=>2)))")
-          ("{S}\\.CC" . "((S=>2)_v^n>>(S=>2))%lex")
+          ("=" . "{(D=>(D=>(S=>2)))_a|(D=>(D=>(S=>2)))_p}")
+          ("{S}\\.CC" . "((S=>2)_v^n>>((S=>2)_v=>((S=>2)_v=>(S=>2))))%lex")
           ("{S}\\.MOD-A" . "((D=>(S=>2))_a>>(D=>(S=>2))_a)")
           ("{S}\\.MOD-N" . "((D=>(S=>2))_n>>(D=>(S=>2))_n)")
           ("MOD-A" . "((D=>(S=>2))=>((D=>(S=>2))_a>>(D=>(S=>2))_a))")
@@ -79,7 +79,7 @@
           ("{S}\\.P-ARG" . "PARG%lex")
           ("\\!|\\?" . "((S=>2)_v>>(S=>2))%lex")
           ;; Only transitive or >arity verbs can be passivized.
-          ("PASV" . "(({D|(D=>(S=>2))}^n=>(D=>(D=>(S=>2))))_V%!pv,lex%>pv,lex)"))
+          ("PASV" . "(({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(D=>(S=>2))))_V%!pv,lex%>pv,lex)"))
 
         *auxiliaries-and-aspectual-operator-semtype-strs*))
       ;; AUX    == ((D=>(S=>2))_V%!T,!X>>(D=>(S=>2))_V%!T,X)
@@ -96,7 +96,7 @@
                              :options
                              (append
                                ;; verbs.
-                               (list (str2semtype "(({D|(D=>(S=>2))}^n=>(D=>(S=>2)))_V%!T,LEX%>T)"))
+                               (list (str2semtype "(({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(S=>2)))_V%!T,LEX%>T)"))
                                ;; Auxiliaries and aspectual operators (prog/perf)
                                ;; Tense will take an aspectual operator and then
                                ;; return the same type except that the range is

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -40,7 +40,7 @@
           ("\\|{N}\\|" . "D%lex")  ; names
           ("\[\\d\|\\.\]\+" . "D%lex")  ; numbers
           ("{S}\\.P" . "(D=>(D=>(S=>2)))_p%lex")
-          ("{S}\\.PS" . "((S=>2)>>((S=>2)>>(S=>2)))%lex")
+          ("{S}\\.PS" . "((S=>2)_v>>((S=>2)_v>>(S=>2)))%lex")
           ;;; Either takes two tensed sentences to make a new tensed sentence or two
           ;;; untensed sentence and makes a new untensed sentence.
           ;("{S}\\.PS" . "{((S=>2)_T=>((S=>2)_T=>(S=>2)_T))|((S=>2)_!T=>((S=>2)_!T=>(S=>2)_!T))}")
@@ -58,26 +58,26 @@
           ("{S}\\.V" . "({D|(D=>(S=>2))}^n=>(D=>(S=>2)))_v%lex")
           ("{S}\\.D" . "({(D=>(S=>2))_n|(D=>(S=>2))_p}=>D)%lex")
           ("{S}\\.ADV-A" . "((D=>(S=>2))_v>>(D=>(S=>2))_v)%lex")
-          ("{S}\\.(ADV-E|ADV-S|ADV-F)" . "((S=>2)>>(S=>2))%lex")
+          ("{S}\\.(ADV-E|ADV-S|ADV-F)" . "((S=>2)_v>>(S=>2))%lex")
           ("PLUR" . "((D=>(S=>2))_n%!pl>>(D=>(S=>2))_n%pl)")
           ("K" . "((D=>(S=>2))_n=>D)")
           ("TO|KA" . "((D=>(S=>2))_v%!t=>D)")
-          ("KE" . "((S=>2)%!t=>D)")
-          ("THAT" . "((S=>2)%t=>D)%lex")
-          ("WHETHER|ANS-TO" . "((S=>2)%t=>D)%lex")
+          ("KE" . "((S=>2)_v%!t=>D)")
+          ("THAT" . "((S=>2)_v%t=>D)%lex")
+          ("WHETHER|ANS-TO" . "((S=>2)_v%t=>D)%lex")
           ("ADV-A" . "((D=>(S=>2))=>((D=>(S=>2))_v>>(D=>(S=>2))_v))")
           ("ADV-E|ADV-S|ADV-F" . "((D=>(S=>2))=>((S=>2)>>(S=>2)))")
           ("FQUAN|NQUAN" . "((D=>(S=>2))_a=>((D=>(S=>2))_n=>D))")
           ("SET-OF" . "(D^n=>(D=>(D=>D)))")
-          ("NOT" . "((S=>2)>>(S=>2))%lex")
+          ("NOT" . "((S=>2)_v>>(S=>2))%lex")
           ("=" . "(D=>(D=>(S=>2)))")
-          ("{S}\\.CC" . "((S=>2)^n>>(S=>2))%lex")
+          ("{S}\\.CC" . "((S=>2)_v^n>>(S=>2))%lex")
           ("{S}\\.MOD-A" . "((D=>(S=>2))_a>>(D=>(S=>2))_a)")
           ("{S}\\.MOD-N" . "((D=>(S=>2))_n>>(D=>(S=>2))_n)")
           ("MOD-A" . "((D=>(S=>2))=>((D=>(S=>2))_a>>(D=>(S=>2))_a))")
           ("MOD-N" . "((D=>(S=>2))=>((D=>(S=>2))_n>>(D=>(S=>2))_n))")
           ("{S}\\.P-ARG" . "PARG%lex")
-          ("\\!|\\?" . "((S=>2)>>(S=>2))%lex")
+          ("\\!|\\?" . "((S=>2)_v>>(S=>2))%lex")
           ;; Only transitive or >arity verbs can be passivized.
           ("PASV" . "(({D|(D=>(S=>2))}^n=>(D=>(D=>(S=>2))))_V%!pv,lex%>pv,lex)"))
 
@@ -125,7 +125,7 @@
                                                (new-semtype
                                                  (str2semtype "D")
                                                  (new-semtype (copy-semtype (domain orig-asp))
-                                                              (str2semtype "(S=>2)%T")
+                                                              (str2semtype "(S=>2)_v%T")
                                                               1 nil
                                                               :conn '>>)
                                                  1 nil)

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -40,7 +40,7 @@
           ("\\|{N}\\|" . "D%lex")  ; names
           ("\[\\d\|\\.\]\+" . "D%lex")  ; numbers
           ("{S}\\.P" . "(D=>(D=>(S=>2)))_p%lex")
-          ("{S}\\.PS" . "((S=>2)_v>>((S=>2)_v>>(S=>2)))%lex")
+          ("{S}\\.PS" . "((S=>2)_v>>((S=>2)_v>>(S=>2))_p)%lex")
           ;;; Either takes two tensed sentences to make a new tensed sentence or two
           ;;; untensed sentence and makes a new untensed sentence.
           ;("{S}\\.PS" . "{((S=>2)_T=>((S=>2)_T=>(S=>2)_T))|((S=>2)_!T=>((S=>2)_!T=>(S=>2)_!T))}")
@@ -74,9 +74,11 @@
           ("NOT" . "((S=>2)_v>>(S=>2))%lex")
           ("=" . "{(D=>(D=>(S=>2)))_a|(D=>(D=>(S=>2)))_p}")
           ("{S}\\.CC" . "((S=>2)_v^n>>((S=>2)_v=>((S=>2)_v=>(S=>2))))%lex")
-          ("{S}\\.MOD-A" . "((D=>(S=>2))_a>>(D=>(S=>2))_a)")
+          ;; Modifies monadic adjective and prepositional predicates, as well as sentential prepositional phrases.
+          ;; TODO: introduce mod-p which operates on the prepositional phrases.
+          ("{S}\\.MOD-A" . "{((D=>(S=>2))_a>>(D=>(S=>2))_a)|{((D=>(S=>2))_p>>(D=>(S=>2))_p)|(((S=>2)_v>>(S=>2))_p=>((S=>2)_v>>(S=>2))_p)}}")
           ("{S}\\.MOD-N" . "((D=>(S=>2))_n>>(D=>(S=>2))_n)")
-          ("MOD-A" . "((D=>(S=>2))=>((D=>(S=>2))_a>>(D=>(S=>2))_a))")
+          ("MOD-A" . "((D=>(S=>2))=>{((D=>(S=>2))_a>>(D=>(S=>2))_a)|{((D=>(S=>2))_p>>(D=>(S=>2))_p)|(((S=>2)_v>>(S=>2))_p=>((S=>2)_v>>(S=>2))_p)}})")
           ("MOD-N" . "((D=>(S=>2))=>((D=>(S=>2))_n>>(D=>(S=>2))_n))")
           ("{S}\\.P-ARG" . "PARG%lex")
           ("\\!|\\?" . "((S=>2)_v>>(S=>2))%lex")

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -46,7 +46,7 @@
           ;("{S}\\.PS" . "{((S=>2)_T=>((S=>2)_T=>(S=>2)_T))|((S=>2)_!T=>((S=>2)_!T=>(S=>2)_!T))}")
           ("{S}\\.N" . "(D=>(S=>2))_n%lex")
           ("{S}-OF\\.N" . "(D=>(D=>(S=>2)))_n%lex")
-          ("{S}\\.A" . "{(D=>(S=>2))_a|(D=>(D=>(S=>2)))_a}%lex")
+          ("{S}\\.A" . "{(D=>(S=>2))_a%lex|(D=>(D=>(S=>2)))_a%lex}")
           ; Note: "be.v" is intentionally placed above "*.v" so that it gets mapped correctly.
           ; Be careful while moving this around so that "be.v" is mapped correctly.
           ; "be.v" can't take plural, perfect, progressive, passive, or
@@ -426,8 +426,16 @@
 
 ;; Returns a string containing the semantic type of a given atomic ULF expression.
 (defun atom-semtype? (expr)
-  (cdr (assoc (atom2str expr) *semtypes*
-              :test (lambda (x y) (string-equal (scan-to-strings y x) x)))))
+  (let ((lookup-expr (cond
+                       ;; For named predicates, use placeholder since current
+                       ;; regex patterns can't handle them.
+                       ((lex-name-prep? expr) 'prep.p)
+                       ((lex-name-adj? expr) 'adj.a)
+                       ((lex-name-det? expr) 'det.d)
+                       ((lex-name-noun? expr) 'noun.n)
+                       (t expr))))
+    (cdr (assoc (atom2str lookup-expr) *semtypes*
+                :test (lambda (x y) (string-equal (scan-to-strings y x) x))))))
 
 ;; TODO: move this into a separate util.lisp file where we'll put other utility
 ;; processing functions.

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -63,8 +63,10 @@
           ("K" . "((D=>(S=>2))_n=>D)")
           ("TO|KA" . "((D=>(S=>2))_v%!t,!x=>D)")
           ("KE" . "((S=>2)_v%!t=>D)")
-          ("THAT" . "((S=>2)_v%t=>D)%lex")
-          ("WHETHER|ANS-TO" . "((S=>2)_v%t=>D)%lex")
+          ("THAT|THT" . "((S=>2)_v%t=>D)%lex")
+          ("WHETHER" . "((S=>2)_v%t=>D)%lex")
+          ;; TODO: add feature for wh-word count.
+          ("ANS-TO" . "((S=>2)_v%t=>D)%lex")
           ("ADV-A" . "((D=>(S=>2))=>((D=>(S=>2))_v>>(D=>(S=>2))_v))")
           ("ADV-E|ADV-S|ADV-F" . "((D=>(S=>2))=>((S=>2)>>(S=>2)))")
           ("FQUAN|NQUAN" . "((D=>(S=>2))_a=>((D=>(S=>2))_n=>D))")

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -54,8 +54,8 @@
           ;   plurals: must be in a kind, (be.v (= (k (plur lawyer.n))))
           ;   perfect, progressive, auxiliary: aspectual operators operate over verbs
           ;   passive: 'be' is an empty auxiliary acting as part of the passive
-          ("BE\\.V" . "({(D=>(S=>2))_A|(D=>(S=>2))_P}=>(D=>(S=>2)))_v%lex,!t")
-          ("{S}\\.V" . "({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(S=>2)))_v%lex,!t")
+          ("BE\\.V" . "({(D=>(S=>2))_A|(D=>(S=>2))_P}=>(D=>(S=>2)))_v%lex,!t,!pf,!pg,!pv,!x")
+          ("{S}\\.V" . "({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(S=>2)))_v%lex,!t,!pf,!pg,!pv,!x")
           ("{S}\\.D" . "({(D=>(S=>2))_n|(D=>(S=>2))_p}=>D)%lex")
           ("{S}\\.ADV-A" . "((D=>(S=>2))_v>>(D=>(S=>2))_v)%lex")
           ("{S}\\.(ADV-E|ADV-S|ADV-F)" . "((S=>2)_v>>(S=>2))%lex")
@@ -83,7 +83,8 @@
           ("{S}\\.P-ARG" . "PARG%lex")
           ("\\!|\\?" . "((S=>2)_v>>(S=>2))%lex")
           ;; Only transitive or >arity verbs can be passivized.
-          ("PASV" . "(({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^n=>(D=>(D=>(S=>2))))_V%!pv,lex%>pv,lex)"))
+          ;; TODO: instead of 2, this should be n-1, which we don't yet support.
+          ("PASV" . "(({D|(D=>(S=>2))%!t,!pf,!pg,!pv,!x}^2=>(D=>(D=>(S=>2))))_V%!pv,!t,lex%>pv,lex)"))
 
         *auxiliaries-and-aspectual-operator-semtype-strs*))
       ;; AUX    == ((D=>(S=>2))_V%!T,!X>>(D=>(S=>2))_V%!T,X)

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -443,6 +443,10 @@
 ;; processing functions.
 ;; Makes an elided ulf token explicit (e.g. {he}.pro -> he.pro)
 (defun make-explicit! (intoken)
+  ;; When this isn't a symbol (e.g., a number) it can't be an elided ulf token.
+  (when (not (symbolp intoken))
+    (return-from make-explicit! intoken))
+  ;; Main body.
   (let ((pkg (symbol-package intoken)))
     (in-ulf-lib (intoken token)
       (multiple-value-bind (word suffix) (split-by-suffix token)


### PR DESCRIPTION
Extends the type system for proper sampling. Mostly this is inserted appropriate syntactic feature restrictions to types so that we can sample the correct structure and only the correct structures. 