### PR TITLE
Added support for underspecified types, with the macro .

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -134,6 +134,9 @@
     :pasv-lex-verb?
     :tensed-lex-verbaux?
 
+    ;; underspecified-patterns.lisp
+    :with-underspecified-types
+
     ;; search.lisp
     :search-vp-head
     :find-vp-head

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -22,6 +22,11 @@
     ("PERF" . "((D=>(S=>2))_v%!t,!pf,!x>>(D=>(S=>2))_v%!t,pf)")
     ("{S}\\.AUX-S|{S}\\.AUX-V" . "((D=>(S=>2))_v%!t,!x>>(D=>(S=>2))_v%!t,x)")))
 
+;;; This parameter forms the basis for all the compositional semantic analysis
+;;; in the package. Modify this variable at your own risk. I would encourage
+;;; using thread-protected and temporary modifications to this variable in
+;;; well-defined scopes. underspecified-patterns.lisp shows an example of this
+;;; sort of modification to the variable.
 (defparameter *semtypes*
   (append
     (mapcar

--- a/ulf-lib.asd
+++ b/ulf-lib.asd
@@ -2,7 +2,7 @@
 (asdf:defsystem :ulf-lib
   :name "Episodic Logic-Unscoped Logical Form (ULF) Interface and Manipulation Library"
   :serial t
-  :version "1.0.1"
+  :version "1.0.2"
   :description "A library for basic interfacing and manipulations of Episodic logic, unscoped logical formulas (ULFs)."
   :author "Gene Louis Kim <gkim21@cs.rochester.edu>"
   :license "MIT"
@@ -18,6 +18,7 @@
                (:file "ttt-lexical-patterns")
                (:file "ttt-phrasal-patterns")
                (:file "gen-phrasal-patterns")
+               (:file "underspecified-patterns")
                (:file "search")
                (:file "macro")
                (:file "preprocess")

--- a/underspecified-patterns.lisp
+++ b/underspecified-patterns.lisp
@@ -1,0 +1,54 @@
+;; ULF patterns for underspecified types.
+;;
+;; These were introduced with Len's constituency tree-to-ulf parsers, which
+;; sometimes could not fully resolve a type. Here are a few examples:
+;;  .aux (could be aux-v or aux-s)
+;;  .adv (could be adv-a, adv-s, adv-e, adv-f)
+;;  fin (could be pres, past, or cf)
+;;  .mod (could be mod-a or mod-n)
+
+(in-package :ulf-lib)
+
+(defun construct-alternative-type-strings (type-strings)
+  "Constructs a new type string that allows all of the given types as options."
+  (cond
+    ((= 1 (length type-strings)) (first type-strings))
+    ((= 2 (length type-strings)) 
+     (str:concat "{" (first type-strings) 
+                 "|" (second type-strings) "}"))
+    (t (str:concat "{" (first type-strings) "|"
+                   (construct-alternative-type-strings (cdr type-strings))
+                   "}"))))
+
+(defparameter *underspecified-semtypes*
+  (mapcar
+    ;; Expand out shorthand in key and convert list of symbols to optional
+    ;; semtype of alternatives.
+    #'(lambda (x)
+        (let* ((key1 (regex-replace-all "{S}" (car x) *atomsymbols*))
+               (finalkey (regex-replace-all "{N}" key1 *innername-symbols*)))
+        (cons finalkey
+              (let ((fn (gute:compose #'semtype2str
+                                      #'atom-semtype?))
+                    (args (cdr x)))
+                (str2semtype
+                  (construct-alternative-type-strings
+                    (mapcar fn (cdr x))))))))
+    ;; Declarative shorthand
+    '(("{S}\\.AUX" . (aux.aux-v aux.aux-s))
+      ("{S}\\.ADV" . (adv.adv-a adv.adv-s adv.adv-e adv.adv-f))
+      ("{S}\\.MOD" . (mod.mod-a mod.mod-n))
+      ("FIN" . (pres past cf)))))
+
+(defmacro with-underspecified-types (&body body)
+  "Runs the body while allowing underspecified semtypes.
+  
+  Within the scope of the macro, the variable *semtypes* is modified so any
+  function that directly interacts with this will be affected. Afterward, the
+  prior *semtypes* steate will be reinstated so any changes to the variable
+  within this scope will be lost.
+  
+  This macro is thread-safe."
+  `(let* ((*semtypes* (append *semtypes* *underspecified-semtypes*)))
+     ,@body))
+


### PR DESCRIPTION
The macro `with-underspecified-types` adds support for underspecified types such as adv, aux, fin. These are defined in `underspecified-patterns.lisp`. This is threadsafe, since the modification to the variable `*semtypes*` is fully localized within a let-scope.