### PR TITLE
Updated ulf-lib/tests test cases to the new syntactic features that w…

### DIFF
--- a/test/semtype.lisp
+++ b/test/semtype.lisp
@@ -66,7 +66,8 @@
   (assert-equality #'semtype-match?-str "({D|2}^n=>S)" "(D=>(2=>(D=>S)))")
   (assert-equality #'semtype-match?-str "({D|2}^n=>S)" "(D=>S)")
   (assert-equality #'semtype-match?-str "({D|2}^n=>S)" "S")
-  (assert-equality #'semtype-match?-str "({D|2}^n=>S)" "(D=>(D=>(D=>(D=>S))))"))
+  (let ((ulf::*semtype-max-exponent* 4))
+    (assert-equality #'semtype-match?-str "({D|2}^n=>S)" "(D=>(D=>(D=>(D=>S))))")))
 
 
 ;; TODO: more extensive semtype-equal? tests.

--- a/ttt-lexical-patterns.lisp
+++ b/ttt-lexical-patterns.lisp
@@ -124,7 +124,7 @@
                     ;;   (((past do.aux-s) you.pro (know.v {ref}.pro)) ?)
                     ;;
                     ;; Inverted type:
-                    ;;   (D=>(ANT>>(S=>2)%T))
+                    ;;   (D=>(ANT>>(S=>2)%T,X))
                     ;;   where ANT is the antecedent of the original
                     ;;   auxiliary. Basically the subject argument
                     ;;   was moved out before the verb.
@@ -136,7 +136,7 @@
                                     (new-semtype
                                       (str2semtype "D")
                                       (new-semtype (copy-semtype (domain orig-asp))
-                                                   (str2semtype "(S=>2)_v%T")
+                                                   (str2semtype "(S=>2)_v%T,X")
                                                    1 nil
                                                    :conn '>>)
                                       1 nil)


### PR DESCRIPTION
…ere introduced. Using semtype-match? more to make the tests robust to future changes in the syntactic features.

Also, correct a small bug in the syntactic features of inverted auxiliaries.